### PR TITLE
update for dropped schema on derivative portal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: geoknife
 Type: Package
 Title: Web-Processing of Large Gridded Datasets
-Version: 1.3.4
+Version: 1.3.5
 Date: 2016-06-09
 Authors@R: c( person("Jordan", "Read", role = c("aut","cre"),
     email = "jread@usgs.gov"),

--- a/R/06-simplegeom-obj.R
+++ b/R/06-simplegeom-obj.R
@@ -28,7 +28,7 @@ setClass(
 setMethod("initialize", signature = "simplegeom", 
           definition = function(.Object, ...) {
             .Object@DRAW_NAMESPACE = 'gov.usgs.cida.gdp.draw'
-            .Object@DRAW_SCHEMA = 'http://cida.usgs.gov/climate/derivative/xsd/draw.xsd'
+            .Object@DRAW_SCHEMA = 'http://cida-test.er.usgs.gov/mda.lakes/draw.xsd'
             .Object@sp <- SpatialPolygons(...)
             return(.Object)
 })

--- a/inst/extdata/multi_poly_post.xml
+++ b/inst/extdata/multi_poly_post.xml
@@ -71,7 +71,7 @@
 			<ows:Identifier>FEATURE_COLLECTION</ows:Identifier>
 			<wps:Data>
 				<wps:ComplexData mimeType="text/xml" schema="http://schemas.opengis.net/gml/3.1.1/base/feature.xsd">
-					<gml:featureMembers xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="gov.usgs.cida.gdp.draw http://cida.usgs.gov/climate/derivative/xsd/draw.xsd">
+					<gml:featureMembers xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="gov.usgs.cida.gdp.draw http://cida-test.er.usgs.gov/mda.lakes/draw.xsd">
 						<draw:poly gml:id="poly.1">
 							<draw:the_geom>
 								<gml:MultiSurface srsDimension="2" srsName="urn:x-ogc:def:crs:EPSG:4326">


### PR DESCRIPTION
currently, 
```r
geoknife(c(-89, 42), 'state::Wisconsin') 
```
would fail because the draw schema that it used is no longer hosted. This is a temporary fix for that, with us hosting that `draw.xsd` file elsewhere and changing the values in `geoknife`'s `simplegeom` to point to it. 