### PR TITLE
fixing issue with progress bar errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: geoknife
 Type: Package
 Title: Web-Processing of Large Gridded Datasets
-Version: 1.6.1
+Version: 1.6.2
 Date: 2018-08-20
 Authors@R: c( person("Jordan", "Read", role = c("aut","cre"),
     email = "jread@usgs.gov"),

--- a/R/waitUntilFinished.R
+++ b/R/waitUntilFinished.R
@@ -38,16 +38,21 @@ setMethod(f = "wait",signature(.Object = "character", sleep.time = "numeric"), d
   running <- running(.Object, retry = TRUE)
   pb <- progress_bar$new(total = 100, clear = FALSE)
   currentStatus <- 'unknown'
+  succeededYet <- FALSE
   while(running){
     Sys.sleep(sleep.time)
     running <- running(.Object, retry = TRUE)
     checkResult <- check(.Object)
-    if(!is.null(checkResult$percentComplete)) {
-      pb$update(as.numeric(checkResult$percentComplete)/100)
+    percentComplete <- checkResult$percentComplete
+    if(!is.null(percentComplete) && !succeededYet) {
+      pb$update(as.numeric(percentComplete)/100)
     } else if(checkResult$status != currentStatus) {
       message(checkResult$status)
     }
     currentStatus <- checkResult$status
+    if(checkResult$statusType == "ProcessSucceeded" && percentComplete == 100) {
+      succeededYet <- TRUE
+    }
   }
   invisible(.Object)
 })


### PR DESCRIPTION
Should fix the more recent part of #366, both original issue and the more recent one.  This checks to be sure the job hasn't already reported a `ProcessSucceeded` statusType or a `percentComplete` of 100, to prevent trying to update the status bar with multiple 100% values and causing an error.  This seems to happen on bigger jobs with a short check interval.  

The original part of #366 will still cause an error.  We could do a similar thing to fix that here too, although that would be kind of papering over a GDP issue.